### PR TITLE
test: remove done callbacks in async tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 env:
   CI: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,8 @@
 name: publish
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - package.json
+  release:
+    types: [published]
 
 env:
   CI: true

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
   },
   "homepage": "https://github.com/haraka/haraka-plugin-relay#readme",
   "dependencies": {
-    "ipaddr.js": "^2.2.0"
+    "ipaddr.js": "^2.3.0"
   },
   "devDependencies": {
-    "@haraka/eslint-config": "^2.0.2",
-    "haraka-test-fixtures": "^1.3.8"
+    "@haraka/eslint-config": "^2.0.3",
+    "haraka-test-fixtures": "^1.3.10"
   },
   "prettier": {
     "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "npx eslint *.js test --fix",
     "prettier": "npx prettier . --check",
     "prettier:fix": "npx prettier . --write --log-level=warn",
-    "test": "npx mocha@^11",
+    "test": "npx mocha",
     "versions": "npx dependency-version-checker check",
     "versions:fix": "npx dependency-version-checker update"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -77,267 +77,296 @@ describe('relay', () => {
   })
 
   describe('acl', () => {
-    beforeEach((done) => {
+    beforeEach(() => {
       this.plugin = new fixtures.plugin('relay')
       this.plugin.cfg = { relay: { dest_domains: true } }
       this.connection = fixtures.connection.createConnection()
-      done()
     })
 
-    it('relay.acl=false', (done) => {
+    it('relay.acl=false', async () => {
       this.plugin.cfg.relay.acl = false
       this.plugin.acl(() => {}, this.connection)
-      this.plugin.pass_relaying((rc) => {
-        assert.equal(undefined, rc)
-        done()
-      }, this.connection)
+      await new Promise((resolve) => {
+        this.plugin.pass_relaying((rc) => {
+          assert.equal(undefined, rc)
+          resolve()
+        }, this.connection)
+      })
     })
 
-    it('relay.acl=true, miss', (done) => {
+    it('relay.acl=true, miss', async () => {
       this.plugin.cfg.relay.acl = true
       this.plugin.acl(() => {}, this.connection)
-      this.plugin.pass_relaying((rc) => {
-        assert.equal(undefined, rc)
-        assert.equal(false, this.connection.relaying)
-        done()
-      }, this.connection)
+      await new Promise((resolve) => {
+        this.plugin.pass_relaying((rc) => {
+          assert.equal(undefined, rc)
+          assert.equal(false, this.connection.relaying)
+          resolve()
+        }, this.connection)
+      })
     })
 
-    it('relay.acl=true, hit', (done) => {
+    it('relay.acl=true, hit', async () => {
       this.plugin.cfg.relay.acl = true
       this.connection.remote.ip = '1.1.1.1'
       this.plugin.acl_allow = ['1.1.1.1/32']
       this.plugin.acl(() => {}, this.connection)
-      this.plugin.pass_relaying((rc) => {
-        assert.equal(OK, rc)
-        assert.equal(true, this.connection.relaying)
-        done()
-      }, this.connection)
+      await new Promise((resolve) => {
+        this.plugin.pass_relaying((rc) => {
+          assert.equal(OK, rc)
+          assert.equal(true, this.connection.relaying)
+          resolve()
+        }, this.connection)
+      })
     })
 
-    it('relay.acl=true, hit, missing mask', (done) => {
+    it('relay.acl=true, hit, missing mask', async () => {
       this.plugin.cfg.relay.acl = true
       this.connection.remote.ip = '1.1.1.1'
       this.plugin.acl_allow = ['1.1.1.1']
       this.plugin.acl(() => {}, this.connection)
-      this.plugin.pass_relaying((rc) => {
-        assert.equal(OK, rc)
-        assert.equal(true, this.connection.relaying)
-        done()
-      }, this.connection)
+      await new Promise((resolve) => {
+        this.plugin.pass_relaying((rc) => {
+          assert.equal(OK, rc)
+          assert.equal(true, this.connection.relaying)
+          resolve()
+        }, this.connection)
+      })
     })
 
-    it('relay.acl=true, hit, net', (done) => {
+    it('relay.acl=true, hit, net', async () => {
       this.plugin.cfg.relay.acl = true
       this.connection.remote.ip = '1.1.1.1'
       this.plugin.acl_allow = ['1.1.1.1/24']
       this.plugin.acl(() => {}, this.connection)
-      this.plugin.pass_relaying((rc) => {
-        assert.equal(OK, rc)
-        assert.equal(true, this.connection.relaying)
-        done()
-      }, this.connection)
+      await new Promise((resolve) => {
+        this.plugin.pass_relaying((rc) => {
+          assert.equal(OK, rc)
+          assert.equal(true, this.connection.relaying)
+          resolve()
+        }, this.connection)
+      })
     })
   })
 
   describe('dest_domains', () => {
-    beforeEach((done) => {
+    beforeEach(() => {
       this.plugin = new fixtures.plugin('relay')
       this.plugin.cfg = { relay: { dest_domains: true } }
 
       this.connection = fixtures.connection.createConnection()
       this.connection.init_transaction()
-
-      done()
     })
 
-    it('relay.dest_domains=false', (done) => {
+    it('relay.dest_domains=false', async () => {
       this.plugin.cfg.relay.dest_domains = false
-      this.plugin.dest_domains(
-        (rc) => {
-          assert.equal(undefined, rc)
-          done()
-        },
-        this.connection,
-        [{ host: 'foo' }],
-      )
+      await new Promise((resolve) => {
+        this.plugin.dest_domains(
+          (rc) => {
+            assert.equal(undefined, rc)
+            resolve()
+          },
+          this.connection,
+          [{ host: 'foo' }],
+        )
+      })
     })
 
-    it('relaying', (done) => {
+    it('relaying', async () => {
       this.connection.relaying = true
-      this.plugin.dest_domains(
-        (rc) => {
-          assert.equal(undefined, rc)
-          assert.equal(
-            1,
-            this.connection.transaction.results.get('relay').skip.length,
-          )
-          done()
-        },
-        this.connection,
-        [{ host: 'foo' }],
-      )
+      await new Promise((resolve) => {
+        this.plugin.dest_domains(
+          (rc) => {
+            assert.equal(undefined, rc)
+            assert.equal(
+              1,
+              this.connection.transaction.results.get('relay').skip.length,
+            )
+            resolve()
+          },
+          this.connection,
+          [{ host: 'foo' }],
+        )
+      })
     })
 
-    it('no config', (done) => {
-      this.plugin.dest_domains(
-        (rc) => {
-          assert.equal(undefined, rc)
-          assert.equal(
-            1,
-            this.connection.transaction.results.get('relay').err.length,
-          )
-          done()
-        },
-        this.connection,
-        [{ host: 'foo' }],
-      )
+    it('no config', async () => {
+      await new Promise((resolve) => {
+        this.plugin.dest_domains(
+          (rc) => {
+            assert.equal(undefined, rc)
+            assert.equal(
+              1,
+              this.connection.transaction.results.get('relay').err.length,
+            )
+            resolve()
+          },
+          this.connection,
+          [{ host: 'foo' }],
+        )
+      })
     })
 
-    it('action=undef', (done) => {
+    it('action=undef', async () => {
       this.plugin.dest = { domains: { foo: '{"action":"dunno"}' } }
-      this.plugin.dest_domains(
-        (rc) => {
-          assert.equal(DENY, rc)
-          assert.equal(
-            1,
-            this.connection.transaction.results.get('relay').fail.length,
-          )
-          done()
-        },
-        this.connection,
-        [{ host: 'foo' }],
-      )
+      await new Promise((resolve) => {
+        this.plugin.dest_domains(
+          (rc) => {
+            assert.equal(DENY, rc)
+            assert.equal(
+              1,
+              this.connection.transaction.results.get('relay').fail.length,
+            )
+            resolve()
+          },
+          this.connection,
+          [{ host: 'foo' }],
+        )
+      })
     })
 
-    it('action=deny', (done) => {
+    it('action=deny', async () => {
       this.plugin.dest = { domains: { foo: '{"action":"deny"}' } }
-      this.plugin.dest_domains(
-        (rc) => {
-          assert.equal(DENY, rc)
-          assert.equal(
-            1,
-            this.connection.transaction.results.get('relay').fail.length,
-          )
-          done()
-        },
-        this.connection,
-        [{ host: 'foo' }],
-      )
+      await new Promise((resolve) => {
+        this.plugin.dest_domains(
+          (rc) => {
+            assert.equal(DENY, rc)
+            assert.equal(
+              1,
+              this.connection.transaction.results.get('relay').fail.length,
+            )
+            resolve()
+          },
+          this.connection,
+          [{ host: 'foo' }],
+        )
+      })
     })
 
-    it('action=continue', (done) => {
+    it('action=continue', async () => {
       this.plugin.dest = { domains: { foo: '{"action":"continue"}' } }
-      this.plugin.dest_domains(
-        (rc) => {
-          assert.equal(CONT, rc)
-          assert.equal(
-            1,
-            this.connection.transaction.results.get('relay').pass.length,
-          )
-          done()
-        },
-        this.connection,
-        [{ host: 'foo' }],
-      )
+      await new Promise((resolve) => {
+        this.plugin.dest_domains(
+          (rc) => {
+            assert.equal(CONT, rc)
+            assert.equal(
+              1,
+              this.connection.transaction.results.get('relay').pass.length,
+            )
+            resolve()
+          },
+          this.connection,
+          [{ host: 'foo' }],
+        )
+      })
     })
 
-    it('action=accept', (done) => {
+    it('action=accept', async () => {
       this.plugin.dest = { domains: { foo: '{"action":"continue"}' } }
-      this.plugin.dest_domains(
-        (rc) => {
-          assert.equal(CONT, rc)
-          assert.equal(
-            1,
-            this.connection.transaction.results.get('relay').pass.length,
-          )
-          done()
-        },
-        this.connection,
-        [{ host: 'foo' }],
-      )
+      await new Promise((resolve) => {
+        this.plugin.dest_domains(
+          (rc) => {
+            assert.equal(CONT, rc)
+            assert.equal(
+              1,
+              this.connection.transaction.results.get('relay').pass.length,
+            )
+            resolve()
+          },
+          this.connection,
+          [{ host: 'foo' }],
+        )
+      })
     })
   })
 
   describe('force_routing', () => {
-    beforeEach((done) => {
+    beforeEach(() => {
       this.plugin = new fixtures.plugin('relay')
       this.plugin.cfg = { relay: { force_routing: true } }
       this.plugin.dest = {}
 
       this.connection = fixtures.connection.createConnection()
       this.connection.init_transaction()
-
-      done()
     })
 
-    it('relay.force_routing=false', (done) => {
+    it('relay.force_routing=false', async () => {
       this.plugin.cfg.relay.force_routing = false
-      this.plugin.force_routing(
-        (rc) => {
-          assert.equal(undefined, rc)
-          done()
-        },
-        this.connection,
-        'foo',
-      )
+      await new Promise((resolve) => {
+        this.plugin.force_routing(
+          (rc) => {
+            assert.equal(undefined, rc)
+            resolve()
+          },
+          this.connection,
+          'foo',
+        )
+      })
     })
 
-    it('dest_domains empty', (done) => {
-      this.plugin.force_routing(
-        (rc) => {
-          assert.equal(undefined, rc)
-          done()
-        },
-        this.connection,
-        'foo',
-      )
+    it('dest_domains empty', async () => {
+      await new Promise((resolve) => {
+        this.plugin.force_routing(
+          (rc) => {
+            assert.equal(undefined, rc)
+            resolve()
+          },
+          this.connection,
+          'foo',
+        )
+      })
     })
 
-    it('dest_domains, no route', (done) => {
+    it('dest_domains, no route', async () => {
       this.plugin.dest = { domains: { foo: '{"action":"blah blah"}' } }
-      this.plugin.force_routing(
-        (rc, nexthop) => {
-          assert.equal(undefined, rc)
-          assert.equal(undefined, nexthop)
-          done()
-        },
-        this.connection,
-        'foo',
-      )
+      await new Promise((resolve) => {
+        this.plugin.force_routing(
+          (rc, nexthop) => {
+            assert.equal(undefined, rc)
+            assert.equal(undefined, nexthop)
+            resolve()
+          },
+          this.connection,
+          'foo',
+        )
+      })
     })
 
-    it('dest_domains, route', (done) => {
+    it('dest_domains, route', async () => {
       this.plugin.dest = {
         domains: { foo: '{"action":"blah blah","nexthop":"other-server"}' },
       }
-      this.plugin.force_routing(
-        (rc, nexthop) => {
-          assert.equal(OK, rc)
-          assert.equal('other-server', nexthop)
-          done()
-        },
-        this.connection,
-        'foo',
-      )
+      await new Promise((resolve) => {
+        this.plugin.force_routing(
+          (rc, nexthop) => {
+            assert.equal(OK, rc)
+            assert.equal('other-server', nexthop)
+            resolve()
+          },
+          this.connection,
+          'foo',
+        )
+      })
     })
 
-    it('dest-domains, any', (done) => {
+    it('dest-domains, any', async () => {
       this.plugin.dest = {
         domains: {
           foo: '{"action":"blah blah","nexthop":"other-server"}',
           any: '{"action":"blah blah","nexthop":"any-server"}',
         },
       }
-      this.plugin.force_routing(
-        (rc, nexthop) => {
-          assert.equal(OK, rc)
-          assert.equal('any-server', nexthop)
-          done()
-        },
-        this.connection,
-        'not',
-      )
+      await new Promise((resolve) => {
+        this.plugin.force_routing(
+          (rc, nexthop) => {
+            assert.equal(OK, rc)
+            assert.equal('any-server', nexthop)
+            resolve()
+          },
+          this.connection,
+          'not',
+        )
+      })
     })
   })
 
@@ -354,28 +383,32 @@ describe('relay', () => {
       assert.equal(this.plugin.register_hook.args[3][1], 'all')
     })
 
-    it('all hook always returns OK', (done) => {
+    it('all hook always returns OK', async () => {
       this.plugin.cfg.relay = { all: true }
-      this.plugin.all(
-        (action) => {
-          assert.equal(action, OK)
-          done()
-        },
-        this.connection,
-        ['foo@bar.com'],
-      )
+      await new Promise((resolve) => {
+        this.plugin.all(
+          (action) => {
+            assert.equal(action, OK)
+            resolve()
+          },
+          this.connection,
+          ['foo@bar.com'],
+        )
+      })
     })
 
-    it('all hook always sets connection.relaying to true', (done) => {
+    it('all hook always sets connection.relaying to true', async () => {
       this.plugin.cfg.relay = { all: true }
-      this.plugin.all(
-        () => {
-          assert.equal(this.connection.relaying, true)
-          done()
-        },
-        this.connection,
-        ['foo@bar.com'],
-      )
+      await new Promise((resolve) => {
+        this.plugin.all(
+          () => {
+            assert.equal(this.connection.relaying, true)
+            resolve()
+          },
+          this.connection,
+          ['foo@bar.com'],
+        )
+      })
     })
   })
 })


### PR DESCRIPTION
- convert callback-style tests to async/await Promise wrappers
- remove unnecessary done callback usage in setup/tests
